### PR TITLE
use strict and warnings everywhere

### DIFF
--- a/1.0/src/exonerate2proteins.pl
+++ b/1.0/src/exonerate2proteins.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -w
 
 use strict; 
+use warnings;
 use Carp; 
 use feature 'say'; 
 use IO::All; 

--- a/1.0/src/fgmp.pl
+++ b/1.0/src/fgmp.pl
@@ -28,6 +28,7 @@
 ##########################################################################
 
 use strict;
+use warnings;
 use feature 'say'; 
 use Data::Dumper; 
 use Carp; 

--- a/1.0/src/filter_unfiltByScore.pl
+++ b/1.0/src/filter_unfiltByScore.pl
@@ -2,6 +2,7 @@
 
 
 use strict; 
+use warnings;
 use feature 'say';
 
 # System Modules

--- a/1.0/src/rename.pl
+++ b/1.0/src/rename.pl
@@ -2,6 +2,7 @@
 
 use Carp;
 use strict;
+use warnings;
 use feature 'say'; 
 use Data::Dumper; 
 

--- a/1.0/src/retrieveFasta.pl
+++ b/1.0/src/retrieveFasta.pl
@@ -1,8 +1,9 @@
 #!/usr/bin/perl -w
 
-
-use Data::Dumper; 
-use Carp; 
+use strict;
+use warnings;
+use Data::Dumper;
+use Carp;
 use feature 'say';
 use Bio::SeqIO;
 
@@ -17,10 +18,10 @@ my %id_hash = ();
 
 open (FILE,$list) || croak "cannot open $list:$!\n";
 while(<FILE>){
-chomp; 
+chomp;
 	$id_hash{$_} = 1;
-	
-} 
+
+}
 
 $new=Bio::SeqIO->new(
 			-file=> $proteomdb,

--- a/1.0/src/run_exonerate.pl
+++ b/1.0/src/run_exonerate.pl
@@ -1,6 +1,7 @@
 #!/opt/perl/5.16.3/bin/perl -w
 
 use strict; 
+use warnings;
 use feature 'say'; 
 use Carp; 
 use Fgmp; 

--- a/1.0/utils/countDomains.pl
+++ b/1.0/utils/countDomains.pl
@@ -1,6 +1,7 @@
 #!/opt/perl/5.16.3/bin/perl -w
 
 use strict; 
+use warnings;
 use Carp; 
 use feature 'say'; 
 use Data::Dumper;

--- a/1.0/utils/simplifyNcbiHeader.pl
+++ b/1.0/utils/simplifyNcbiHeader.pl
@@ -4,6 +4,7 @@ use feature 'say';
 use Data::Dumper; 
 use Carp; 
 use strict; 
+use warnings;
 
 
 my $in = shift; 


### PR DESCRIPTION
As #2 removes some `-w` and [`use warnings`](https://metacpan.org/pod/warnings#What's-wrong-with-w-and-$%5EW) is better.