### PR TITLE
cpanfile to aid dependency installation

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,3 @@
+requires 'Bio::Perl';
+requires 'IO::All';
+requires 'IPC::Run';


### PR DESCRIPTION
Like the look of version 2. Here's a small addition to help sysadmins/users install the *perl* dependencies thus:

```bash
cpanm --installdeps .
```